### PR TITLE
@types/node should be in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,8 @@
     "url": "git://github.com/NightlyCommit/twig-lexer"
   },
   "license": "Apache-2.0",
-  "dependencies": {
-    "@types/node": "^12.0.8"
-  },
   "devDependencies": {
+    "@types/node": "^12.0.8",
     "@types/sinon": "^7.0.13",
     "@types/tape": "^4.2.33",
     "coveralls": "^3.0.4",


### PR DESCRIPTION
Having `@types/node` in `dependencies` is a mistake, yes?